### PR TITLE
Add raw audio format option for ESPHome support

### DIFF
--- a/custom_components/astromech/tts.py
+++ b/custom_components/astromech/tts.py
@@ -109,18 +109,17 @@ class TextToAstromech(tts.TextToSpeechEntity):
 
         data = self._r2.generate(slug)
 
+        output_stream = io.BytesIO()
+        output_file = wave.open(output_stream, "wb")
+        output_file.setnchannels(1)  # mono
+        output_file.setsampwidth(2)  # 16 bits
+        output_file.setframerate(22050)  # Hz
+        output_file.writeframes(data)
+        output_file.close()
+
+        # Read the content of the byte stream into a byte array
+        byte_array = output_stream.getvalue()
+
         if options[tts.ATTR_AUDIO_OUTPUT] == "wav":
-            output_stream = io.BytesIO()
-            output_file = wave.open(output_stream, "wb")
-            output_file.setnchannels(1)  # mono
-            output_file.setsampwidth(2)  # 16 bits
-            output_file.setframerate(22050)  # Hz
-            output_file.writeframes(data)
-            output_file.close()
-
-            # Read the content of the byte stream into a byte array
-            byte_array = output_stream.getvalue()
-
             return ("wav", byte_array)
-
-        return ("raw", data)
+        return ("raw", byte_array)

--- a/custom_components/astromech/tts.py
+++ b/custom_components/astromech/tts.py
@@ -83,7 +83,12 @@ class TextToAstromech(tts.TextToSpeechEntity):
     @property
     def supported_options(self) -> list[str]:
         """Return a list of supported options."""
-        return [tts.ATTR_VOICE]
+        return [tts.ATTR_AUDIO_OUTPUT, tts.ATTR_VOICE]
+
+    @property
+    def default_options(self):
+        """Return a dict include default options."""
+        return {tts.ATTR_AUDIO_OUTPUT: "wav"}
 
     @callback
     def async_get_supported_voices(self, language: str) -> list[Voice] | None:
@@ -94,25 +99,28 @@ class TextToAstromech(tts.TextToSpeechEntity):
         ]
 
     def get_tts_audio(
-        self, message: str, language: str, options: dict[str, Any] | None = None
+        self, message: str, language: str, options: dict[str, Any]
     ) -> tts.TtsAudioType:
         """Load tts audio file from the engine."""
         slug = replace_non_alpha_chars(message.lower())
 
-        if options.get("voice") == VOICE_ASTROMECH_SHORT:
+        if options.get(tts.ATTR_VOICE) == VOICE_ASTROMECH_SHORT:
             slug = generate_hash(message.lower(), 6)
 
         data = self._r2.generate(slug)
 
-        output_stream = io.BytesIO()
-        output_file = wave.open(output_stream, "wb")
-        output_file.setnchannels(1)  # mono
-        output_file.setsampwidth(2)  # 16 bits
-        output_file.setframerate(22050)  # Hz
-        output_file.writeframes(data)
-        output_file.close()
+        if options[tts.ATTR_AUDIO_OUTPUT] == "wav":
+            output_stream = io.BytesIO()
+            output_file = wave.open(output_stream, "wb")
+            output_file.setnchannels(1)  # mono
+            output_file.setsampwidth(2)  # 16 bits
+            output_file.setframerate(22050)  # Hz
+            output_file.writeframes(data)
+            output_file.close()
 
-        # Read the content of the byte stream into a byte array
-        byte_array = output_stream.getvalue()
+            # Read the content of the byte stream into a byte array
+            byte_array = output_stream.getvalue()
 
-        return ("wav", byte_array)
+            return ("wav", byte_array)
+
+        return ("raw", data)


### PR DESCRIPTION
ESPHome voice assistant device use raw audio (https://esphome.io/components/speaker/index.html)

This PR adds this support so Astromech TTS can be used in ESPHome.